### PR TITLE
Add LangChain/DSpy setup against a local Ollama container instance

### DIFF
--- a/notebooks/LangChain_DSpy_Ollama_Setup.ipynb
+++ b/notebooks/LangChain_DSpy_Ollama_Setup.ipynb
@@ -1,0 +1,128 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# LangChain/DSpy Setup with Local Ollama Container Instance\n",
+    "\n",
+    "This notebook demonstrates how to set up LangChain and DSpy to work with a local Ollama container instance. We will cover the installation of necessary packages, configuration, and connection to the local Ollama instance."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1: Install Necessary Packages\n",
+    "\n",
+    "First, we need to install the required packages. Run the following command to install LangChain, DSpy, and other dependencies."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install langchain dspy requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2: Import Packages\n",
+    "\n",
+    "Next, we will import the necessary packages for our setup."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import langchain\n",
+    "import dspy\n",
+    "import requests"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3: Configure Connection to Local Ollama Instance\n",
+    "\n",
+    "We need to configure the connection to our local Ollama container instance. The following code sets up the connection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OLLAMA_API_URL = \"http://localhost:11434/api\"\n",
+    "\n",
+    "def get_ollama_version():\n",
+    "    response = requests.get(f\"{OLLAMA_API_URL}/version\")\n",
+    "    if response.status_code == 200:\n",
+    "        return response.json()\n",
+    "    else:\n",
+    "        return None\n",
+    "\n",
+    "ollama_version = get_ollama_version()\n",
+    "if ollama_version:\n",
+    "    print(f\"Connected to Ollama version: {ollama_version}\")\n",
+    "else:\n",
+    "    print(\"Failed to connect to Ollama instance.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4: Minimal Documentation and Instructions\n",
+    "\n",
+    "### LangChain\n",
+    "LangChain is a framework for building applications with large language models (LLMs). It provides tools and abstractions to simplify the development process.\n",
+    "\n",
+    "### DSpy\n",
+    "DSpy is a data science library that offers various utilities for data manipulation, analysis, and visualization.\n",
+    "\n",
+    "### Ollama\n",
+    "Ollama is a containerized environment for running and managing LLMs. It provides an API for interacting with the models.\n",
+    "\n",
+    "### Setup Instructions\n",
+    "1. Ensure Docker is installed and running on your machine.\n",
+    "2. Run the Ollama container using the following command:\n",
+    "   ```\n",
+    "   docker run -d --gpus=all -v ollama:/root/.ollama -p 11434:11434 --name ollama ollama/ollama\n",
+    "   ```\n",
+    "3. Verify the Ollama instance is running by accessing [http://localhost:11434/api/version](http://localhost:11434/api/version).\n",
+    "4. Follow the steps in this notebook to install packages, import them, and configure the connection to the Ollama instance."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Add a Jupyter notebook for LangChain/DSpy setup against a local Ollama container instance.

* Create `notebooks/LangChain_DSpy_Ollama_Setup.ipynb` with markdown and code cells.
* Include instructions for installing necessary packages, importing packages, and configuring the connection to a local Ollama instance.
* Provide minimal documentation and setup instructions for LangChain, DSpy, and Ollama.

