### PR TITLE
#51: Document duplicate detection triggers (opened + edited)

### DIFF
--- a/.github/workflows/create_issue_comment.yml
+++ b/.github/workflows/create_issue_comment.yml
@@ -1,7 +1,9 @@
+﻿# Duplicate Issue Detection — TF-IDF similarity (see .github/scripts/identify_duplicates.py).
+# Triggers: opened + edited. Rationale: docs/development/adr-001-duplicate-issue-detection-triggers.md
+# — edited allows E2E validation without new throwaway issues; re-checks when title/body change.
 name: Duplicate Issue Detection
 on:
   issues:
-    # opened: new issues; edited: body/title may become similar to another issue later
     types: [opened, edited]
 
 jobs:

--- a/docs/development/WORKFLOW_CONFIGURATION.md
+++ b/docs/development/WORKFLOW_CONFIGURATION.md
@@ -122,8 +122,9 @@ Use this when validating the Issue Analyzer after changes (for example, issues #
 **Duplicate Issue Detection** (`create_issue_comment.yml`):
 
 - Triggered on **issue opened** and **issue edited** (re-checks similarity if body/title change). If similar issues were already posted as a comment, an **edit** does not add a duplicate of that comment.
+- **Why `edited` is intentional:** enables end-to-end checks by **editing** an issue to overlap another (fewer disposable test issues), and re-runs when edits move text closer to a possible duplicate. See [ADR-001](adr-001-duplicate-issue-detection-triggers.md).
 - There is no `workflow_dispatch` for this workflow.
-- To validate: open a short test issue, optionally **edit** it to overlap another issue’s text, then check for a **Potential Duplicate Issues** comment and the Actions run for errors.
+- To validate (preferred): **edit** an issue so its text overlaps another issue’s text, then confirm a green Actions run for `issues` / `edited` and (if similarity ≥ threshold) a **Potential Duplicate Issues** comment. Optionally open a short test issue for the `opened` path.
 
 ## Configuration Options
 

--- a/docs/development/adr-001-duplicate-issue-detection-triggers.md
+++ b/docs/development/adr-001-duplicate-issue-detection-triggers.md
@@ -1,0 +1,28 @@
+# ADR-001: Duplicate Issue Detection triggers (`opened` and `edited`)
+
+## Status
+
+Accepted
+
+## Context
+
+The workflow [`.github/workflows/create_issue_comment.yml`](../../.github/workflows/create_issue_comment.yml) runs [`.github/scripts/identify_duplicates.py`](../../.github/scripts/identify_duplicates.py) on GitHub issue events of types **`opened`** and **`edited`**. After refactoring removed unused OpenAI-related code from the script (TF-IDF + cosine similarity only), we need a clear record of why both event types stay enabled.
+
+## Decision
+
+Keep **`issues: opened`** and **`issues: edited`** as workflow triggers. Do not narrow the workflow to `opened` only.
+
+## Rationale
+
+1. **Validation and hygiene:** Maintainers can verify duplicate detection end-to-end by **editing** an issue to add text that overlaps another issue, without opening short-lived test issues for every check.
+2. **Behaviour when scope changes:** When someone edits a title or body and the text moves closer to an existing issue, re-running similarity helps surface potential duplicates. The script avoids posting a second “Potential duplicate issues” comment if one already exists on the thread (see `issue_already_has_duplicate_comment` in `identify_duplicates.py`).
+
+## Consequences
+
+- Issue Analyzer ([`issue-analyzer.yml`](../../.github/workflows/issue-analyzer.yml)) is a separate automation; both workflows may react to the same `edited` event for different purposes.
+- Documentation for manual validation should prefer the **`edited`** path when possible to reduce noise from disposable issues.
+
+## References
+
+- [WORKFLOW_CONFIGURATION.md](WORKFLOW_CONFIGURATION.md) — Duplicate Issue Detection section
+- GitHub issue [#51](https://github.com/pkuppens/my_chat_gpt/issues/51) — validation tracker


### PR DESCRIPTION
Ref #51

Adds ADR-001, workflow YAML header comments, and extends WORKFLOW_CONFIGURATION for why `issues: edited` stays enabled (E2E without extra issues, re-check on duplicate-prone edits).

**Does not close #51** — issue acceptance checkboxes need an edit-based E2E run and log check after this merges.

**Files**
- `docs/development/adr-001-duplicate-issue-detection-triggers.md`
- `docs/development/WORKFLOW_CONFIGURATION.md`
- `.github/workflows/create_issue_comment.yml`
